### PR TITLE
Agrego regla en gitlab-ci para solo ejecutar pipeline en la rama principal

### DIFF
--- a/templates/default/.gitlab-ci.yml
+++ b/templates/default/.gitlab-ci.yml
@@ -11,3 +11,9 @@ pages:
   artifacts:
     paths:
       - public
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      changes:
+        - src/**/**
+        - package.json
+        - package-lock.json


### PR DESCRIPTION
El pipeline se va a ejecutar solamente en la rama principal y ante cambios en `src`, `package.json` y `package-lock.json`